### PR TITLE
Add support for array-contains

### DIFF
--- a/query.go
+++ b/query.go
@@ -142,9 +142,13 @@ func (q *Query) Filter(filterStr string, value interface{}) *Query {
 		q.err = errors.New("datastore: invalid filter: " + filterStr)
 		return q
 	}
+
 	f := filter{
 		FieldName: strings.TrimRight(filterStr, " ><=!"),
 		Value:     value,
+	}
+	if strings.HasSuffix(f.FieldName, " array-contains") {
+		f.FieldName = strings.TrimSpace(strings.TrimSuffix(f.FieldName, " array-contains"))
 	}
 	switch op := strings.TrimSpace(filterStr[len(f.FieldName):]); op {
 	case "<=":

--- a/query.go
+++ b/query.go
@@ -28,14 +28,16 @@ const (
 	equal
 	greaterEq
 	greaterThan
+	arrayContains
 )
 
 var operatorToProto = map[operator]pb.StructuredQuery_FieldFilter_Operator{
-	lessThan:    pb.StructuredQuery_FieldFilter_LESS_THAN,
-	lessEq:      pb.StructuredQuery_FieldFilter_LESS_THAN_OR_EQUAL,
-	equal:       pb.StructuredQuery_FieldFilter_EQUAL,
-	greaterEq:   pb.StructuredQuery_FieldFilter_GREATER_THAN_OR_EQUAL,
-	greaterThan: pb.StructuredQuery_FieldFilter_GREATER_THAN,
+	lessThan:      pb.StructuredQuery_FieldFilter_LESS_THAN,
+	lessEq:        pb.StructuredQuery_FieldFilter_LESS_THAN_OR_EQUAL,
+	equal:         pb.StructuredQuery_FieldFilter_EQUAL,
+	greaterEq:     pb.StructuredQuery_FieldFilter_GREATER_THAN_OR_EQUAL,
+	greaterThan:   pb.StructuredQuery_FieldFilter_GREATER_THAN,
+	arrayContains: pb.StructuredQuery_FieldFilter_ARRAY_CONTAINS,
 }
 
 // filter is a conditional filter on query results.
@@ -155,6 +157,8 @@ func (q *Query) Filter(filterStr string, value interface{}) *Query {
 		f.Op = greaterThan
 	case "=":
 		f.Op = equal
+	case "array-contains":
+		f.Op = arrayContains
 	default:
 		q.err = fmt.Errorf("datastore: invalid operator %q in filter %q", op, filterStr)
 		return q

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,29 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	pb "google.golang.org/genproto/googleapis/firestore/v1"
+)
+
+func TestArrayContainsFilter(t *testing.T) {
+	q := NewQuery("User").Filter("foo array-contains", 5)
+
+	ctx := context.Background()
+	var req pb.RunQueryRequest
+	client := client{"test-project", "projects/test-project/databases/(default)", nil}
+	err := q.toProto(ctx, &req, &client)
+	if err != nil {
+		t.Errorf("toProto failed: %v", err)
+	}
+	t.Logf(proto.MarshalTextString(&req))
+	filter := req.GetStructuredQuery().Where.GetFieldFilter()
+	if filter.Op != pb.StructuredQuery_FieldFilter_ARRAY_CONTAINS {
+		t.Errorf("Query protobuf filter operator was incorrect, got: %d, want: %d.", filter.Op, pb.StructuredQuery_FieldFilter_ARRAY_CONTAINS)
+	}
+	if filter.Field.FieldPath != "foo" {
+		t.Errorf("Query protobuf filter field path was incorrect, got: %s, want: %s.", filter.Field.FieldPath, "foo")
+	}
+}


### PR DESCRIPTION
Update the datastore package to have an explicit array-contains rather than relying on '=' to mean array-contains